### PR TITLE
Included functionality to calculate satellite ground tracks

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 from flask import Flask, render_template, request
-#from satellite_tracker import get_satellite_location
+from satellite_tracker import get_ground_track
 
 app = Flask(__name__)
 
@@ -14,8 +14,8 @@ def satellite_tracker():
     if request.method == 'POST':
         user_satellite = request.form.get("satellite", None)
         if user_satellite!=None:
-            location = "This satellite is not yet implemented"
-            return render_template("satellite_tracker.html", response = [user_satellite, location])
+            lat, lon = get_ground_track(user_satellite)
+            return render_template("satellite_tracker.html", response = [user_satellite, lat[0], lon[0]])
 
     return render_template("satellite_tracker.html")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Flask
 Werkzeug
-poliastro
-TLE-tools
+datetime
+pytz
+skyfield

--- a/satellite_tracker.py
+++ b/satellite_tracker.py
@@ -1,0 +1,58 @@
+# General imports
+from urllib.request import urlopen
+
+# Time imports
+import datetime
+import pytz
+
+# Astrodynamics imports
+from skyfield.api import load, EarthSatellite
+
+
+SATELLITE_TO_NORAD = dict(icesat2 = 43613,
+                          iss = 25544)
+
+
+def query_tle(satellite, IS_NORAD = False):
+    '''
+    Request the tle from a specific satellite from celestrek.org
+    '''
+
+    # IF satellite is given, get its norad
+    if not IS_NORAD:
+        NORAD_ID = SATELLITE_TO_NORAD[satellite]
+    else:
+        NORAD_ID = satellite
+
+    # Download TLE of last known position
+    URL = f'https://celestrak.org/NORAD/elements/gp.php?CATNR={NORAD_ID}FORMAT=TLE'
+    TLE_string = urlopen(URL).read().decode('utf-8')
+    TLE_lines = TLE_string.strip().splitlines()
+
+    return TLE_lines
+
+def get_ground_track(satellite, IS_NORAD = False):
+
+    '''
+    Return an ephemeris of requested satellite in lat/lon for a ground track
+    '''
+    # Get tle lines
+    TLE_lines = query_tle(satellite, IS_NORAD = IS_NORAD)
+
+    # Create skyfield satellite object and load skyfield times
+    sat = EarthSatellite(TLE_lines[1], TLE_lines[2])
+    ts = load.timescale(builtin=True)
+
+    # Create 270 minutes ahead from now in steps of 1 minute
+    base = datetime.datetime.now(pytz.utc)
+    datetime_times = [base + datetime.timedelta(minutes=x) for x in range(0, 270)]
+    times = ts.from_datetimes(datetime_times)
+
+    # Get satellite ephemeris in lat/lon
+    geocentric = sat.at(times)
+    subsat = geocentric.subpoint()
+
+    lon = subsat.longitude.degrees
+    lat = subsat.latitude.degrees
+
+    return lat, lon

--- a/templates/satellite_tracker.html
+++ b/templates/satellite_tracker.html
@@ -23,8 +23,10 @@
     <!-- Respond to chosen satellite -->
     <div id="result">
       {% if response is defined %}
-          You have selected: {{ response[0] }} <br>
-          {{ response[1] }}
+          You have selected: {{ response[0] }} <br> <br>
+          Current position:<br>
+          lat = {{ response[1] }} <br>
+          lon = {{ response[2] }}
       {% endif %}
     </div>
 


### PR DESCRIPTION
There is now functionality to calculate the ground tracks for ICESAT-2 and ISS for the next 270 minutes. However, the website only prints the current lat/lon position.