### PR TITLE
Bug fix: celestrak api requires new URL format

### DIFF
--- a/get_tle_firestore.py
+++ b/get_tle_firestore.py
@@ -46,7 +46,7 @@ def query_tle(norad):
     '''
 
     # Download TLE of last known position
-    URL = f'https://celestrak.org/NORAD/elements/gp.php?CATNR={norad}FORMAT=TLE'
+    URL = f'https://celestrak.org/NORAD/elements/gp.php?CATNR={norad}&FORMAT=TLE'
     TLE_string = urlopen(URL).read().decode('utf-8')
     TLE_lines = TLE_string.strip().splitlines()
 

--- a/get_tle_local.py
+++ b/get_tle_local.py
@@ -56,7 +56,7 @@ def query_tle(norad):
     '''
 
     # Download TLE of last known position
-    URL = f'https://celestrak.org/NORAD/elements/gp.php?CATNR={norad}FORMAT=TLE'
+    URL = f'https://celestrak.org/NORAD/elements/gp.php?CATNR={norad}&FORMAT=TLE'
     TLE_string = urlopen(URL).read().decode('utf-8')
     TLE_lines = TLE_string.strip().splitlines()
 

--- a/satellite_tracker.py
+++ b/satellite_tracker.py
@@ -32,7 +32,7 @@ MU_EARTH = 3.986004418e14
 def get_tle(norad, method):
 
     if method == "local":
-        return get_tle_firestore(norad)
+        return get_tle_local(norad)
 
     if method == "firestore":
         return get_tle_firestore(norad)


### PR DESCRIPTION
So the satellite tracker broke down suddenly. Error showing was this: 

```
 Traceback (most recent call last):
  File "/layers/google.python.pip/pip/lib/python3.9/site-packages/flask/app.py", line 2528, in wsgi_app
    response = self.full_dispatch_request()
  File "/layers/google.python.pip/pip/lib/python3.9/site-packages/flask/app.py", line 1825, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/layers/google.python.pip/pip/lib/python3.9/site-packages/flask/app.py", line 1823, in full_dispatch_request
    rv = self.dispatch_request()
  File "/layers/google.python.pip/pip/lib/python3.9/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/srv/main.py", line 78, in satellite_tracker
    ground_track = [coord for coord in zip(sat_data['sat_lat'], sat_data['sat_lon'])]
TypeError: 'NoneType' object is not subscriptable
```


Turned out that the prompt to the Celestrak.org API was no longer valid. It used to be this: 

`URL = f'https://celestrak.org/NORAD/elements/gp.php?CATNR={norad}FORMAT=TLE'`

But it is now this: 

`URL = f'https://celestrak.org/NORAD/elements/gp.php?CATNR={norad}&FORMAT=TLE'`

Information on this prompt and the various options can be found [here](https://celestrak.org/NORAD/documentation/gp-data-formats.php): 

This pull request fixes the bug.

