### PR TITLE
Specify version of flask

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask
+Flask==2.3.1
 Werkzeug
 datetime
 pytz


### PR DESCRIPTION
An error occurred within the `flask-googlemaps `package. 

`File "/srv/main.py", line 2, in <module>
    from flask_googlemaps import GoogleMaps, Map
  File "/layers/google.python.pip/pip/lib/python3.9/site-packages/flask_googlemaps/__init__.py", line 8, in <module>
    from flask import Blueprint, Markup, g, render_template
ImportError: cannot import name 'Markup' from 'flask' (/layers/google.python.pip/pip/lib/python3.9/site-packages/flask/__init__.py)`

This happened because for flask > 2.4 the Markup has been deprecated. Most likely a new standard version of flask, higher than 2.4 was installed on the Google App Engine. The attempted solution here is to specify the older flask version that is known to work. 
